### PR TITLE
Add GitHub Linguist to remove notebook from repo stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Override jupyter in Github language stats for more accurate estimate of repo code languages
+# Reference: https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code
+*.ipynb linguist-generated


### PR DESCRIPTION
## Chores

- Add github linguist to remove notebook from repo stats