### PR TITLE
Fix colpali after upgrading colpali-engine to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies = [
     "datasets>=2.15.0,<3.0.0",
-    "colpali-engine==0.2.2",
+    "colpali-engine>=0.3.0",
     "einops>=0.8.0,<1.0.0",
     "GPUtil>=1.4.0,<2.0.0",
     "loguru>=0.7.0,<1.0.0",

--- a/src/vidore_benchmark/retrievers/colpali_retriever.py
+++ b/src/vidore_benchmark/retrievers/colpali_retriever.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import List, Optional, TypeVar, cast
 
 import torch
-from colpali_engine.models.paligemma_colbert_architecture import ColPali
+from colpali_engine.models import ColPali
 from dotenv import load_dotenv
 from loguru import logger
 from PIL import Image


### PR DESCRIPTION
With this the more modular ColPali (since 0.3.0) is supported in the benchmark.