### PR TITLE
Load processor using ColPali model name

### DIFF
--- a/src/vidore_benchmark/generate_similarity_maps.py
+++ b/src/vidore_benchmark/generate_similarity_maps.py
@@ -49,7 +49,6 @@ def generate_similarity_maps(
 
     # Load the model and LORA adapter
     model_name = "vidore/colpali-v1.2"
-    processor_name = "google/paligemma-3b-mix-448"
     model = cast(
         ColPali,
         ColPali.from_pretrained(
@@ -60,7 +59,7 @@ def generate_similarity_maps(
     )
 
     # Load the processor
-    processor = cast(ColPaliProcessor, ColPaliProcessor.from_pretrained(processor_name))
+    processor = cast(ColPaliProcessor, ColPaliProcessor.from_pretrained(model_name))
     print("Loaded custom processor.\n")
 
     images = [Image.open(img_filepath) for img_filepath in documents]

--- a/src/vidore_benchmark/interpretability/vit_configs.py
+++ b/src/vidore_benchmark/interpretability/vit_configs.py
@@ -23,4 +23,7 @@ VIT_CONFIG: Dict[str, ViTConfig] = {
     "vidore/colpaligemma-3b-pt-448-base": ViTConfig(
         patch_size=14, resolution=448
     ),  # Copied from "google/paligemma-3b-mix-448"
+    "vidore/colpali": ViTConfig(patch_size=14, resolution=448),  # Copied from "google/paligemma-3b-mix-448"
+    "vidore/colpali-v1.1": ViTConfig(patch_size=14, resolution=448),  # Copied from "google/paligemma-3b-mix-448"
+    "vidore/colpali-v1.2": ViTConfig(patch_size=14, resolution=448),  # Copied from "google/paligemma-3b-mix-448"
 }


### PR DESCRIPTION
## Description

Since the `preprocessor_config.json` is in the [ColPali Hf Hub repository](https://huggingface.co/vidore/colpali-v1.2/tree/main), it is possible to load the processor using the ColPali model name instead of the base PaliGemma name.

### Changes

- Use the ColPali model name to load ColPaliProcessor instead of the PaliGemma one

## Note

This PR is similar to https://github.com/illuin-tech/colpali/pull/72.