### PR TITLE
Rename ColPali model alias to match model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ can evaluate the ColPali model on the ViDoRe benchmark to reproduce the results 
 
 ```bash
 vidore-benchmark evaluate-retriever \
-    --model-name vidore/colpali \
+    --model-name vidore/colpali-v1.2 \
     --collection-name "vidore/vidore-benchmark-667173f98e70a1c0fa4db00d" \
     --split test
 ```
@@ -77,7 +77,7 @@ Alternatively, you can evaluate your model on a single dataset. If your retriver
 
 ```bash
 vidore-benchmark evaluate-retriever \
-    --model-name vidore/colpali \
+    --model-name vidore/colpali-v1.2 \
     --dataset-name vidore/docvqa_test_subsampled \
     --split test
 ```
@@ -99,7 +99,7 @@ You can use token pooling to reduce the length of the document embeddings. In pr
 
 ```bash
 vidore-benchmark evaluate-retriever \
-    --model-name vidore/colpali \
+    --model-name vidore/colpali-v1.2 \
     --dataset-name vidore/docvqa_test_subsampled \
     --split test \
     --use-token-pooling \
@@ -110,7 +110,7 @@ vidore-benchmark evaluate-retriever \
 
 ```bash
 vidore-benchmark retrieve-on-dataset \
-    --model-name vidore/colpali \
+    --model-name vidore/colpali-v1.2 \
     --query "Which hour of the day had the highest overall electricity generation in 2019?" \
     --k 5 \
     --dataset-name vidore/syntheticDocQA_energy_test \

--- a/src/vidore_benchmark/retrievers/colpali_retriever.py
+++ b/src/vidore_benchmark/retrievers/colpali_retriever.py
@@ -29,7 +29,7 @@ class ListDataset(Dataset[T]):
         return self.elements[idx]
 
 
-@register_vision_retriever("vidore/colpali")
+@register_vision_retriever("vidore/colpali-v1.2")
 class ColPaliRetriever(VisionRetriever):
     """
     ColPali Retriever that implements the model from "ColPali: Efficient Document Retrieval


### PR DESCRIPTION
## Features

### Fixed

- Rename ColPali model alias to match model name (use `--model-name vidore/colpali-v1.2` instead of `--model-name vidore/colpali` with the `vidore-benchmark evaluate-retriever` CLI)