### PR TITLE
Fix evaluation script when used with BM25 retriever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [Unreleased]
+
+### Fixed
+
+- Fix `evaluate_dataset` when used with the BM25 retriever
+
 ## [4.0.2] - 2024-10-17
 
 ### Deprecated

--- a/src/vidore_benchmark/evaluation/evaluate.py
+++ b/src/vidore_benchmark/evaluation/evaluate.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 
 from vidore_benchmark.compression.quantization.embedding_binarizer import BaseEmbeddingQuantizer
 from vidore_benchmark.compression.token_pooling import BaseEmbeddingPooler
+from vidore_benchmark.retrievers.bm25_retriever import BM25Retriever
 from vidore_benchmark.retrievers.vision_retriever import VisionRetriever
 
 
@@ -46,6 +47,13 @@ def evaluate_dataset(
         if len(queries) == 0:
             raise ValueError("All queries are None")
     documents = ds[col_documents]
+
+    # Edge case: using the BM25Retriever
+    if isinstance(vision_retriever, BM25Retriever):
+        scores = vision_retriever.get_scores_bm25(queries=queries, documents=documents)
+        relevant_docs, results = vision_retriever.get_relevant_docs_results(ds, queries, scores)
+        metrics = vision_retriever.compute_metrics(relevant_docs, results)
+        return metrics
 
     # Get the embeddings for the queries and documents
     emb_queries = vision_retriever.forward_queries(queries, batch_size=batch_query)

--- a/src/vidore_benchmark/retrievers/bm25_retriever.py
+++ b/src/vidore_benchmark/retrievers/bm25_retriever.py
@@ -41,8 +41,6 @@ class BM25Retriever(VisionRetriever):
         self,
         queries: List[str],
         documents: Union[List[Image.Image], List[str]],
-        batch_query: int,
-        batch_doc: int,
         **kwargs,
     ) -> torch.Tensor:
         # Sanity check: `documents` must be a list of filepaths (strings)


### PR DESCRIPTION
## Features

### Fixed

- Fix `evaluate_dataset` when used with the BM25 retriever