### PR TITLE
Fix redundant query forward pass in eval loop

### DIFF
--- a/src/vidore_benchmark/evaluation/evaluate.py
+++ b/src/vidore_benchmark/evaluation/evaluate.py
@@ -56,8 +56,10 @@ def evaluate_dataset(
         return metrics
 
     # Get the embeddings for the queries and documents
-    # NOTE: To prevent overloading the RAM for large datasets, we will forward both queries and documents
-    # in batches. Note that this is optimization is not related to the model's forward pass.
+    # NOTE: To prevent overloading the RAM for large datasets, we will load the documents (images)
+    # that will be fed to the model in batches (this should be fine for queries as their memory footprint
+    # is negligible. This optimization is about efficient data loading, and is not related to the model's
+    # forward pass which is also batched.
     emb_queries = vision_retriever.forward_queries(queries, batch_size=batch_query)
     emb_documents: List[torch.Tensor] = []
 

--- a/src/vidore_benchmark/evaluation/evaluate.py
+++ b/src/vidore_benchmark/evaluation/evaluate.py
@@ -61,9 +61,7 @@ def evaluate_dataset(
     emb_queries = vision_retriever.forward_queries(queries, batch_size=batch_query)
     emb_documents: List[torch.Tensor] = []
 
-    # might just be batch_doc
-    # dataloader_prebatch_size = max(batch_query, batch_doc)
-    dataloader_prebatch_size = batch_doc
+    dataloader_prebatch_size = 10 * batch_doc
 
     for doc_batch in tqdm(
         batched(ds, n=dataloader_prebatch_size),

--- a/src/vidore_benchmark/evaluation/evaluate.py
+++ b/src/vidore_benchmark/evaluation/evaluate.py
@@ -58,19 +58,18 @@ def evaluate_dataset(
     # Get the embeddings for the queries and documents
     # NOTE: To prevent overloading the RAM for large datasets, we will forward both queries and documents
     # in batches. Note that this is optimization is not related to the model's forward pass.
-    emb_queries: List[torch.Tensor] = []
+    emb_queries = vision_retriever.forward_queries(queries, batch_size=batch_query)
     emb_documents: List[torch.Tensor] = []
 
-    dataloader_prebatch_size = max(batch_query, batch_doc)
+    # might just be batch_doc
+    # dataloader_prebatch_size = max(batch_query, batch_doc)
+    dataloader_prebatch_size = batch_doc
 
     for doc_batch in tqdm(
         batched(ds, n=dataloader_prebatch_size),
         desc="Dataloader pre-batching",
         total=math.ceil(len(ds) / (dataloader_prebatch_size)),
     ):
-        queries: List[str] = [query for query in queries]
-        emb_queries = vision_retriever.forward_queries(queries, batch_size=batch_query)
-
         documents: List[Any] = [db[col_documents] for db in doc_batch]
         emb_documents.extend(vision_retriever.forward_documents(documents, batch_size=batch_doc))
 


### PR DESCRIPTION
queries are encoded in the for loop 