### PR TITLE
Add metadata field to benchmark results + use Pydantic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ feat: add better soft dep handling + change `get_scores` signature + add `scorin
 ### Added
 
 - Add support for ColQwen2, DSEQwen2, and Cohere API embedding models
-- Add Pydantic models for storing the ViDoRe benchmark results and metadata (includes package hash)
+- Add Pydantic models for storing the ViDoRe benchmark results and metadata (includes `vidore-benchmark` version)
 - Add option to create an `EvalManager` instance from `ViDoReBenchmarkResults`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ feat: add better soft dep handling + change `get_scores` signature + add `scorin
 ### Added
 
 - Add support for ColQwen2, DSEQwen2, and Cohere API embedding models
+- Add Pydantic models for storing the ViDoRe benchmark results and metadata (includes pacakge hash metadata)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ feat: add better soft dep handling + change `get_scores` signature + add `scorin
 ### Added
 
 - Add support for ColQwen2, DSEQwen2, and Cohere API embedding models
-- Add Pydantic models for storing the ViDoRe benchmark results and metadata (includes pacakge hash metadata)
+- Add Pydantic models for storing the ViDoRe benchmark results and metadata (includes package hash)
+- Add option to create an `EvalManager` instance from `ViDoReBenchmarkResults`
 
 ### Changed
 
@@ -46,6 +47,8 @@ feat: add better soft dep handling + change `get_scores` signature + add `scorin
 - Add fixtures in retriever tests to speed up testing
 - Add tests for `evaluate_dataset` method
 - Add E2E test for cli command `evaluate-retriever`
+- Add tests for `ViDoReBenchmarkResults`
+- Add tests for `EvalManager`
 
 ## [4.0.2] - 2024-10-17
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "mteb>=1.16.0,<1.17.0",
     "numpy>=1.21.2,<2.0.0",
     "pdf2image>=1.17.0,<2.0.0",
+    "pydantic>=2.0.0,<3.0.0",
     "python-dotenv>=1.0.1,<2.0.0",
     "sentence-transformers>=3.0.1,<4.0.0",
     "sentencepiece>=0.2.0,<1.0.0",

--- a/src/vidore_benchmark/evaluation/eval_manager.py
+++ b/src/vidore_benchmark/evaluation/eval_manager.py
@@ -49,20 +49,41 @@ class EvalManager:
     @classmethod
     def from_dict(cls, data: Dict[Any, Any]):
         """
-        Load evaluation results from a dictionary.
+        Load evaluation results from a Python dictionary.
 
-        Expected format:
-        {
-            "model1": pd.read_json(path1).T.stack(),
-            "model2": pd.read_json(path2).T.stack(),
-        }
+        Example usage:
 
+        ```python
+        >>> import pandas as pd
+        >>> data = {
+                "model1": pd.Series(
+                    {
+                        ("dataset1", "metric1"): 0.8,
+                        ("dataset1", "metric2"): 0.7,
+                        ("dataset2", "metric1"): 0.6,
+                    }
+                ),
+                "model2": pd.Series(
+                    {
+                        ("dataset1", "metric1"): 0.9,
+                        ("dataset1", "metric2"): 0.85,
+                        ("dataset2", "metric1"): 0.75,
+                    }
+                ),
+            }
+        >>> eval_manager = EvalManager.from_dict(sample_data)
+        >>> print(eval_manager.data)
         """
         df = pd.DataFrame.from_dict(data, orient="index")
         return cls(df)
 
     @classmethod
     def from_json(cls, path: Union[str, Path]):
+        """
+        Load evaluation results from a JSON file.
+
+        Refer to the `from_dict` method for more details about the expected format of the JSON file.
+        """
         datapath = Path(path)
         if not datapath.is_file():
             raise FileNotFoundError(f"{path} is not a file")
@@ -72,6 +93,11 @@ class EvalManager:
 
     @classmethod
     def from_multiple_json(cls, paths: Union[List[str], List[Path]]):
+        """
+        Load evaluation results from multiple JSON files.
+
+        Refer to the `from_dict` method for more details about the expected format of the JSON file.
+        """
         data = {}
         for path in paths:
             datapath = Path(path)
@@ -82,6 +108,11 @@ class EvalManager:
 
     @classmethod
     def from_dir(cls, datadir: Union[str, Path]):
+        """
+        Load evaluation results from a directory containing JSON files.
+
+        Refer to the `from_dict` method for more details about the expected format of the JSON file.
+        """
         datadir_ = Path(datadir)
         if not datadir_.is_dir():
             raise FileNotFoundError(f"{datadir} is not a directory")

--- a/src/vidore_benchmark/evaluation/eval_manager.py
+++ b/src/vidore_benchmark/evaluation/eval_manager.py
@@ -5,6 +5,8 @@ from typing import Any, ClassVar, Dict, List, Optional, Union
 
 import pandas as pd
 
+from vidore_benchmark.evaluation.interfaces import ViDoReBenchmarkResults
+
 
 class EvalManager:
     """
@@ -31,6 +33,18 @@ class EvalManager:
 
     def __str__(self) -> str:
         return self.data.__str__()
+
+    @classmethod
+    def from_vidore_results(
+        cls,
+        results: ViDoReBenchmarkResults,
+        model_name: str,
+    ) -> EvalManager:
+        """
+        Create an EvalManager from a ViDoReBenchmarkResults object.
+        """
+        data = {model_name: pd.DataFrame(results.metrics).T.stack()}
+        return cls.from_dict(data)
 
     @classmethod
     def from_dict(cls, data: Dict[Any, Any]):

--- a/src/vidore_benchmark/evaluation/evaluate.py
+++ b/src/vidore_benchmark/evaluation/evaluate.py
@@ -21,7 +21,7 @@ def evaluate_dataset(
     batch_passage: int,
     batch_score: Optional[int] = None,
     embedding_pooler: Optional[BaseEmbeddingPooler] = None,
-) -> Dict[str, float]:
+) -> Dict[str, Optional[float]]:
     """
     Evaluate the model on a given dataset using the MTEB metrics.
 

--- a/src/vidore_benchmark/evaluation/interfaces.py
+++ b/src/vidore_benchmark/evaluation/interfaces.py
@@ -4,92 +4,6 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel
 
 
-class MetricsModel(BaseModel):
-    """
-    Metrics model for the ViDoRe benchmark results.
-    Contains the default MTEB metrics: nDCG, MAP, Recall, Precision, MRR, and NAUCS.
-
-    Example usage:
-
-    ```python
-    >>> metrics = MetricsModel(
-            ndcg_at_1=0.5,
-            ndcg_at_3=0.7,
-            map_at_1=0.4,
-        )
-    >>> # Serialize the model to JSON
-    >>> json_data = metrics.model_dump_json()
-    """
-
-    # nDCG metrics
-    ndcg_at_1: Optional[float] = None
-    ndcg_at_3: Optional[float] = None
-    ndcg_at_5: Optional[float] = None
-    ndcg_at_10: Optional[float] = None
-    ndcg_at_20: Optional[float] = None
-    ndcg_at_50: Optional[float] = None
-    ndcg_at_100: Optional[float] = None
-
-    # MAP metrics
-    map_at_1: Optional[float] = None
-    map_at_3: Optional[float] = None
-    map_at_5: Optional[float] = None
-    map_at_10: Optional[float] = None
-    map_at_20: Optional[float] = None
-    map_at_50: Optional[float] = None
-    map_at_100: Optional[float] = None
-
-    # Recall metrics
-    recall_at_1: Optional[float] = None
-    recall_at_3: Optional[float] = None
-    recall_at_5: Optional[float] = None
-    recall_at_10: Optional[float] = None
-    recall_at_20: Optional[float] = None
-    recall_at_50: Optional[float] = None
-    recall_at_100: Optional[float] = None
-
-    # Precision metrics
-    precision_at_1: Optional[float] = None
-    precision_at_3: Optional[float] = None
-    precision_at_5: Optional[float] = None
-    precision_at_10: Optional[float] = None
-    precision_at_20: Optional[float] = None
-    precision_at_50: Optional[float] = None
-    precision_at_100: Optional[float] = None
-
-    # MRR metrics
-    mrr_at_1: Optional[float] = None
-    mrr_at_3: Optional[float] = None
-    mrr_at_5: Optional[float] = None
-    mrr_at_10: Optional[float] = None
-    mrr_at_20: Optional[float] = None
-    mrr_at_50: Optional[float] = None
-    mrr_at_100: Optional[float] = None
-
-    # NAUCS metrics
-    naucs_at_1_max: Optional[float] = None
-    naucs_at_1_std: Optional[float] = None
-    naucs_at_1_diff1: Optional[float] = None
-    naucs_at_3_max: Optional[float] = None
-    naucs_at_3_std: Optional[float] = None
-    naucs_at_3_diff1: Optional[float] = None
-    naucs_at_5_max: Optional[float] = None
-    naucs_at_5_std: Optional[float] = None
-    naucs_at_5_diff1: Optional[float] = None
-    naucs_at_10_max: Optional[float] = None
-    naucs_at_10_std: Optional[float] = None
-    naucs_at_10_diff1: Optional[float] = None
-    naucs_at_20_max: Optional[float] = None
-    naucs_at_20_std: Optional[float] = None
-    naucs_at_20_diff1: Optional[float] = None
-    naucs_at_50_max: Optional[float] = None
-    naucs_at_50_std: Optional[float] = None
-    naucs_at_50_diff1: Optional[float] = None
-    naucs_at_100_max: Optional[float] = None
-    naucs_at_100_std: Optional[float] = None
-    naucs_at_100_diff1: Optional[float] = None
-
-
 class MetadataModel(BaseModel):
     """
     Metadata data for the ViDoRe benchmark results.
@@ -132,10 +46,10 @@ class ViDoReBenchmarkResults(BaseModel):
                 vidore_benchmark_version="0.0.1.dev7+g462dc4f.d20241102",
             ),
             metrics={
-                "vidore/syntheticDocQA_dummy": MetricsModel(
-                    ndcg_at_1=1.0,
-                    ndcg_at_3=1.0,
-                )
+                "vidore/syntheticDocQA_dummy": {
+                    "ndcg_at_1": 1.0,
+                    "ndcg_at_3": 1.0,
+                }
             }
         )
     >>> # Serialize the model to JSON
@@ -144,7 +58,7 @@ class ViDoReBenchmarkResults(BaseModel):
     """
 
     metadata: MetadataModel
-    metrics: Dict[str, MetricsModel]
+    metrics: Dict[str, Dict[str, Optional[float]]]
 
     @classmethod
     def merge(cls, results: List["ViDoReBenchmarkResults"]) -> "ViDoReBenchmarkResults":
@@ -171,7 +85,7 @@ class ViDoReBenchmarkResults(BaseModel):
         merged_metadata = latest_result.metadata
 
         # Merge all metrics, later results override earlier ones for the same benchmark
-        merged_metrics: Dict[str, MetricsModel] = {}
+        merged_metrics: Dict[str, Dict[str, Optional[float]]] = {}
         for result in results:
             if set(merged_metrics.keys()).intersection(set(result.metrics.keys())):
                 raise ValueError("Duplicate dataset keys found in the input results")

--- a/src/vidore_benchmark/evaluation/interfaces.py
+++ b/src/vidore_benchmark/evaluation/interfaces.py
@@ -6,7 +6,19 @@ from pydantic import BaseModel
 
 class MetricsModel(BaseModel):
     """
-    Metrics model for the ViDoRe benchmark results. Contains the default MTER metrics.
+    Metrics model for the ViDoRe benchmark results.
+    Contains the default MTEB metrics: nDCG, MAP, Recall, Precision, MRR, and NAUCS.
+
+    Example usage:
+
+    ```python
+    >>> metrics = MetricsModel(
+            ndcg_at_1=0.5,
+            ndcg_at_3=0.7,
+            map_at_1=0.4,
+        )
+    >>> # Serialize the model to JSON
+    >>> json_data = metrics.model_dump_json()
     """
 
     # nDCG metrics
@@ -80,19 +92,36 @@ class MetricsModel(BaseModel):
 
 class MetadataModel(BaseModel):
     """
-    Metadata for the ViDoRe benchmark results.
+    Metadata data for the ViDoRe benchmark results.
+
+    Example usage:
+
+    ```python
+    >>> from datetime import datetime
+    >>> metadata = MetadataModel(
+            timestamp=datetime.now(),
+            vidore_benchmark_version="0.0.1.dev7+g462dc4f.d20241102",
+        )
+    >>> # Serialize the model to JSON
+    >>> json_data = metadata.model_dump_json()
+    ```
     """
 
     timestamp: datetime
     vidore_benchmark_version: str
 
+    # NOTE: `Config` is used to allow extra fields in the model
     class Config:
         extra = "allow"
 
 
 class ViDoReBenchmarkResults(BaseModel):
     """
-    A Pydantic model for the ViDoRe benchmark results.
+    ViDoRe benchmark results.
+
+    This Pydantic model contains:
+    - Metadata: Information about the benchmark run, including the timestamp and the `vidore-benchmark` package version.
+    - Metrics: Dictionary of metrics: the keys are the dataset names and the values are the metrics for that dataset.
 
     Example usage:
 
@@ -100,7 +129,7 @@ class ViDoReBenchmarkResults(BaseModel):
     >>> root = RootModel(
             metadata=Metadata(
                 timestamp=datetime.now(),
-                vidore_benchmark_hash="1234567890abcdef",
+                vidore_benchmark_version="0.0.1.dev7+g462dc4f.d20241102",
             ),
             metrics={
                 "vidore/syntheticDocQA_dummy": MetricsModel(
@@ -109,6 +138,7 @@ class ViDoReBenchmarkResults(BaseModel):
                 )
             }
         )
+    >>> # Serialize the model to JSON
     >>> json_data = root.model_dump_json()
     ```
     """
@@ -119,7 +149,8 @@ class ViDoReBenchmarkResults(BaseModel):
     @classmethod
     def merge(cls, results: List["ViDoReBenchmarkResults"]) -> "ViDoReBenchmarkResults":
         """
-        Merge multiple ViDoReBenchmarkResults instances into a single one.
+        Merge multiple `ViDoReBenchmarkResults` instances into a single one.
+
         Uses the latest timestamp from the input results and combines all metrics.
         If there are conflicting metrics for the same benchmark, the last one in the list takes precedence.
 
@@ -127,7 +158,7 @@ class ViDoReBenchmarkResults(BaseModel):
             results: List of ViDoReBenchmarkResults to merge
 
         Returns:
-            A new ViDoReBenchmarkResults instance containing the merged data
+            A new `ViDoReBenchmarkResults` instance containing the merged data
 
         Raises:
             ValueError: If the input list is empty

--- a/src/vidore_benchmark/evaluation/interfaces.py
+++ b/src/vidore_benchmark/evaluation/interfaces.py
@@ -142,6 +142,8 @@ class ViDoReBenchmarkResults(BaseModel):
         # Merge all metrics, later results override earlier ones for the same benchmark
         merged_metrics: Dict[str, MetricsModel] = {}
         for result in results:
+            if set(merged_metrics.keys()).intersection(set(result.metrics.keys())):
+                raise ValueError("Duplicate dataset keys found in the input results")
             merged_metrics.update(result.metrics)
 
         return cls(metadata=merged_metadata, metrics=merged_metrics)

--- a/src/vidore_benchmark/evaluation/interfaces.py
+++ b/src/vidore_benchmark/evaluation/interfaces.py
@@ -9,7 +9,7 @@ class MetricsModel(BaseModel):
     Metrics model for the ViDoRe benchmark results. Contains the default MTER metrics.
     """
 
-    # NDCG metrics
+    # nDCG metrics
     ndcg_at_1: Optional[float] = None
     ndcg_at_3: Optional[float] = None
     ndcg_at_5: Optional[float] = None

--- a/src/vidore_benchmark/evaluation/interfaces.py
+++ b/src/vidore_benchmark/evaluation/interfaces.py
@@ -1,0 +1,117 @@
+from datetime import datetime
+from typing import Dict, Optional
+
+from pydantic import BaseModel
+
+
+class MetricsModel(BaseModel):
+    """
+    Metrics model for the ViDoRe benchmark results. Contains the default MTER metrics.
+    """
+
+    # NDCG metrics
+    ndcg_at_1: Optional[float] = None
+    ndcg_at_3: Optional[float] = None
+    ndcg_at_5: Optional[float] = None
+    ndcg_at_10: Optional[float] = None
+    ndcg_at_20: Optional[float] = None
+    ndcg_at_50: Optional[float] = None
+    ndcg_at_100: Optional[float] = None
+
+    # MAP metrics
+    map_at_1: Optional[float] = None
+    map_at_3: Optional[float] = None
+    map_at_5: Optional[float] = None
+    map_at_10: Optional[float] = None
+    map_at_20: Optional[float] = None
+    map_at_50: Optional[float] = None
+    map_at_100: Optional[float] = None
+
+    # Recall metrics
+    recall_at_1: Optional[float] = None
+    recall_at_3: Optional[float] = None
+    recall_at_5: Optional[float] = None
+    recall_at_10: Optional[float] = None
+    recall_at_20: Optional[float] = None
+    recall_at_50: Optional[float] = None
+    recall_at_100: Optional[float] = None
+
+    # Precision metrics
+    precision_at_1: Optional[float] = None
+    precision_at_3: Optional[float] = None
+    precision_at_5: Optional[float] = None
+    precision_at_10: Optional[float] = None
+    precision_at_20: Optional[float] = None
+    precision_at_50: Optional[float] = None
+    precision_at_100: Optional[float] = None
+
+    # MRR metrics
+    mrr_at_1: Optional[float] = None
+    mrr_at_3: Optional[float] = None
+    mrr_at_5: Optional[float] = None
+    mrr_at_10: Optional[float] = None
+    mrr_at_20: Optional[float] = None
+    mrr_at_50: Optional[float] = None
+    mrr_at_100: Optional[float] = None
+
+    # NAUCS metrics
+    naucs_at_1_max: Optional[float] = None
+    naucs_at_1_std: Optional[float] = None
+    naucs_at_1_diff1: Optional[float] = None
+    naucs_at_3_max: Optional[float] = None
+    naucs_at_3_std: Optional[float] = None
+    naucs_at_3_diff1: Optional[float] = None
+    naucs_at_5_max: Optional[float] = None
+    naucs_at_5_std: Optional[float] = None
+    naucs_at_5_diff1: Optional[float] = None
+    naucs_at_10_max: Optional[float] = None
+    naucs_at_10_std: Optional[float] = None
+    naucs_at_10_diff1: Optional[float] = None
+    naucs_at_20_max: Optional[float] = None
+    naucs_at_20_std: Optional[float] = None
+    naucs_at_20_diff1: Optional[float] = None
+    naucs_at_50_max: Optional[float] = None
+    naucs_at_50_std: Optional[float] = None
+    naucs_at_50_diff1: Optional[float] = None
+    naucs_at_100_max: Optional[float] = None
+    naucs_at_100_std: Optional[float] = None
+    naucs_at_100_diff1: Optional[float] = None
+
+
+class Metadata(BaseModel):
+    """
+    Metadata for the ViDoRe benchmark results.
+    """
+
+    timestamp: datetime
+    vidore_benchmark_hash: str
+
+    class Config:
+        extra = "allow"
+
+
+class ViDoReBenchmarkResults(BaseModel):
+    """
+    A Pydantic model for the ViDoRe benchmark results.
+
+    Example usage:
+
+    ```python
+    >>> root = RootModel(
+            metadata=Metadata(
+                timestamp=datetime.now(),
+                vidore_benchmark_hash="1234567890abcdef",
+            ),
+            metrics={
+                "vidore/syntheticDocQA_dummy": MetricsModel(
+                    ndcg_at_1=1.0,
+                    ndcg_at_3=1.0,
+                )
+            }
+        )
+    >>> json_data = root.model_dump_json()
+    ```
+    """
+
+    metadata: Metadata
+    metrics: Dict[str, MetricsModel]

--- a/src/vidore_benchmark/evaluation/interfaces.py
+++ b/src/vidore_benchmark/evaluation/interfaces.py
@@ -84,7 +84,7 @@ class MetadataModel(BaseModel):
     """
 
     timestamp: datetime
-    vidore_benchmark_hash: str
+    vidore_benchmark_version: str
 
     class Config:
         extra = "allow"

--- a/src/vidore_benchmark/main.py
+++ b/src/vidore_benchmark/main.py
@@ -117,7 +117,7 @@ def evaluate_retriever(
         else:
             savepath = OUTPUT_DIR / f"{model_id}_metrics.json"
 
-        print(f"NDCG@5 for {model_id} on {dataset_name}: {metrics[dataset_name]['ndcg_at_5']}")
+        print(f"nDCG@5 for {model_id} on {dataset_name}: {metrics[dataset_name]['ndcg_at_5']}")
 
         results = ViDoReBenchmarkResults(
             metadata=MetadataModel(
@@ -173,7 +173,7 @@ def evaluate_retriever(
             else:
                 savepath = savedir / f"{dataset_item_id}_metrics.json"
 
-            print(f"NDCG@5 for {model_id} on {dataset_name}: {metrics[dataset_name]['ndcg_at_5']}")
+            print(f"nDCG@5 for {model_id} on {dataset_name}: {metrics[dataset_name]['ndcg_at_5']}")
 
             results = ViDoReBenchmarkResults(
                 metadata=MetadataModel(

--- a/src/vidore_benchmark/main.py
+++ b/src/vidore_benchmark/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from datetime import datetime
+from importlib.metadata import version
 from pathlib import Path
 from typing import Annotated, Dict, List, Optional, cast
 
@@ -121,7 +122,7 @@ def evaluate_retriever(
         results = ViDoReBenchmarkResults(
             metadata=MetadataModel(
                 timestamp=datetime.now(),
-                vidore_benchmark_hash=os.popen("git rev-parse HEAD").read().strip(),
+                vidore_benchmark_version=version("vidore_benchmark"),
             ),
             metrics={dataset_name: MetricsModel(**metrics[dataset_name])},
         )
@@ -177,7 +178,7 @@ def evaluate_retriever(
             results = ViDoReBenchmarkResults(
                 metadata=MetadataModel(
                     timestamp=datetime.now(),
-                    vidore_benchmark_hash=os.popen("git rev-parse HEAD").read().strip(),
+                    vidore_benchmark_version=os.popen("git rev-parse HEAD").read().strip(),
                 ),
                 metrics={dataset_name: MetricsModel(**metrics[dataset_name])},
             )

--- a/src/vidore_benchmark/main.py
+++ b/src/vidore_benchmark/main.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv
 
 from vidore_benchmark.compression.token_pooling import HierarchicalEmbeddingPooler
 from vidore_benchmark.evaluation.evaluate import evaluate_dataset, get_top_k
-from vidore_benchmark.evaluation.interfaces import MetadataModel, MetricsModel, ViDoReBenchmarkResults
+from vidore_benchmark.evaluation.interfaces import MetadataModel, ViDoReBenchmarkResults
 from vidore_benchmark.retrievers.registry_utils import load_vision_retriever_from_registry
 from vidore_benchmark.utils.image_utils import generate_dataset_from_img_folder
 from vidore_benchmark.utils.logging_utils import setup_logging
@@ -124,7 +124,7 @@ def evaluate_retriever(
                 timestamp=datetime.now(),
                 vidore_benchmark_version=version("vidore_benchmark"),
             ),
-            metrics={dataset_name: MetricsModel(**metrics[dataset_name])},
+            metrics={dataset_name: metrics[dataset_name]},
         )
 
         with open(str(savepath), "w", encoding="utf-8") as f:
@@ -180,7 +180,7 @@ def evaluate_retriever(
                     timestamp=datetime.now(),
                     vidore_benchmark_version=os.popen("git rev-parse HEAD").read().strip(),
                 ),
-                metrics={dataset_name: MetricsModel(**metrics[dataset_name])},
+                metrics={dataset_name: metrics[dataset_name]},
             )
             results_all.append(results)
 

--- a/src/vidore_benchmark/retrievers/bge_m3_retriever.py
+++ b/src/vidore_benchmark/retrievers/bge_m3_retriever.py
@@ -87,6 +87,9 @@ class BGEM3Retriever(VisionRetriever):
         passage_embeddings: Union[torch.Tensor, List[torch.Tensor]],
         batch_size: Optional[int] = None,
     ) -> torch.Tensor:
+        """
+        Dot-product similarity between queries and passages.
+        """
         if isinstance(query_embeddings, list):
             query_embeddings = torch.stack(query_embeddings)
         if isinstance(passage_embeddings, list):

--- a/src/vidore_benchmark/retrievers/cohere_api_retriever.py
+++ b/src/vidore_benchmark/retrievers/cohere_api_retriever.py
@@ -116,6 +116,9 @@ class CohereAPIRetriever(VisionRetriever):
         passage_embeddings: Union[torch.Tensor, List[torch.Tensor]],
         batch_size: Optional[int] = None,
     ) -> torch.Tensor:
+        """
+        Dot-product similarity between queries and passages.
+        """
         if isinstance(query_embeddings, list):
             query_embeddings = torch.stack(query_embeddings)
         if isinstance(passage_embeddings, list):

--- a/src/vidore_benchmark/retrievers/dse_qwen2_retriever.py
+++ b/src/vidore_benchmark/retrievers/dse_qwen2_retriever.py
@@ -177,9 +177,9 @@ class DSEQwen2Retriever(VisionRetriever):
         Dot-product similarity between queries and passages.
         """
         if isinstance(query_embeddings, list):
-            query_embeddings = torch.stack(query_embeddings).to(self.device)
+            query_embeddings = torch.stack(query_embeddings)
         if isinstance(passage_embeddings, list):
-            passage_embeddings = torch.stack(passage_embeddings).to(self.device)
+            passage_embeddings = torch.stack(passage_embeddings)
 
         scores = torch.einsum("bd,cd->bc", query_embeddings, passage_embeddings)
 

--- a/src/vidore_benchmark/retrievers/dse_qwen2_retriever.py
+++ b/src/vidore_benchmark/retrievers/dse_qwen2_retriever.py
@@ -173,6 +173,9 @@ class DSEQwen2Retriever(VisionRetriever):
         passage_embeddings: Union[torch.Tensor, List[torch.Tensor]],
         batch_size: Optional[int] = None,
     ) -> torch.Tensor:
+        """
+        Dot-product similarity between queries and passages.
+        """
         if isinstance(query_embeddings, list):
             query_embeddings = torch.stack(query_embeddings).to(self.device)
         if isinstance(passage_embeddings, list):

--- a/src/vidore_benchmark/retrievers/dummy_retriever.py
+++ b/src/vidore_benchmark/retrievers/dummy_retriever.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from typing import List, Optional, Union
 
 import torch
@@ -14,29 +13,30 @@ from vidore_benchmark.retrievers.vision_retriever import VisionRetriever
 @register_vision_retriever("dummy_retriever")
 class DummyRetriever(VisionRetriever):
     """
-    Dummy retriever for testing purposes. It generates random embeddings and scores.
-
-    NOTE: The dummy retriever takes PIL images in its `forward_documents` method.
+    Dummy retriever that generates random dense embeddings.
     """
 
     def __init__(
         self,
         emb_dim_query: int = 16,
         emb_dim_doc: int = 16,
+        device: str = "cpu",
     ):
         super().__init__()
+
         self.emb_dim_query = emb_dim_query
         self.emb_dim_doc = emb_dim_doc
+        self.device = device
 
     @property
     def use_visual_embedding(self) -> bool:
         return True
 
-    def forward_queries(self, queries: List[str], batch_size: int, **kwargs) -> List[Tensor]:
-        return [torch.randn(batch_size, self.emb_dim_query) for _ in range(math.ceil(len(queries) / batch_size))]
+    def forward_queries(self, queries: List[str], batch_size: int, **kwargs) -> Tensor:
+        return torch.randn(len(queries), self.emb_dim_query).to(self.device)
 
-    def forward_passages(self, passages: List[Image.Image], batch_size: int, **kwargs) -> List[Tensor]:
-        return [torch.randn(batch_size, self.emb_dim_doc) for _ in range(math.ceil(len(passages) / batch_size))]
+    def forward_passages(self, passages: List[Image.Image], batch_size: int, **kwargs) -> Tensor:
+        return torch.randn(len(passages), self.emb_dim_doc).to(self.device)
 
     def get_scores(
         self,
@@ -44,4 +44,14 @@ class DummyRetriever(VisionRetriever):
         passage_embeddings: Union[torch.Tensor, List[torch.Tensor]],
         batch_size: Optional[int] = None,
     ) -> torch.Tensor:
-        return torch.rand(len(query_embeddings), len(passage_embeddings))
+        """
+        Dot-product similarity between queries and passages.
+        """
+        if isinstance(query_embeddings, list):
+            query_embeddings = torch.stack(query_embeddings)
+        if isinstance(passage_embeddings, list):
+            passage_embeddings = torch.stack(passage_embeddings)
+
+        scores = torch.einsum("bd,cd->bc", query_embeddings, passage_embeddings)
+
+        return scores

--- a/src/vidore_benchmark/retrievers/jina_clip_retriever.py
+++ b/src/vidore_benchmark/retrievers/jina_clip_retriever.py
@@ -83,6 +83,9 @@ class JinaClipRetriever(VisionRetriever):
         passage_embeddings: Union[torch.Tensor, List[torch.Tensor]],
         batch_size: Optional[int] = None,
     ) -> torch.Tensor:
+        """
+        Dot-product similarity between queries and passages.
+        """
         if isinstance(query_embeddings, list):
             query_embeddings = torch.stack(query_embeddings)
         if isinstance(passage_embeddings, list):

--- a/src/vidore_benchmark/retrievers/nomic_retriever.py
+++ b/src/vidore_benchmark/retrievers/nomic_retriever.py
@@ -110,6 +110,9 @@ class NomicVisionRetriever(VisionRetriever):
         passage_embeddings: Union[torch.Tensor, List[torch.Tensor]],
         batch_size: Optional[int] = None,
     ) -> torch.Tensor:
+        """
+        Dot-product similarity between queries and passages.
+        """
         if isinstance(query_embeddings, list):
             query_embeddings = torch.stack(query_embeddings)
         if isinstance(passage_embeddings, list):

--- a/src/vidore_benchmark/retrievers/siglip_retriever.py
+++ b/src/vidore_benchmark/retrievers/siglip_retriever.py
@@ -78,6 +78,9 @@ class SigLIPRetriever(VisionRetriever):
         passage_embeddings: Union[torch.Tensor, List[torch.Tensor]],
         batch_size: Optional[int] = None,
     ) -> torch.Tensor:
+        """
+        Dot-product similarity between queries and passages.
+        """
         if isinstance(query_embeddings, list):
             query_embeddings = torch.stack(query_embeddings)
         if isinstance(passage_embeddings, list):

--- a/src/vidore_benchmark/retrievers/vision_retriever.py
+++ b/src/vidore_benchmark/retrievers/vision_retriever.py
@@ -137,7 +137,7 @@ class VisionRetriever(ABC):
         relevant_docs: Any,
         results: Any,
         **kwargs,
-    ):
+    ) -> Dict[str, Optional[float]]:
         """
         Compute the MTEB metrics.
 

--- a/tests/cli/test_e2e_evaluate_retriever.py
+++ b/tests/cli/test_e2e_evaluate_retriever.py
@@ -81,13 +81,5 @@ def test_evaluate_retriever_e2e(cli_runner, output_dir):
     # Check if metrics contain the expected dataset
     assert dataset_name in metrics, f"Metrics for dataset {dataset_name} not found"
 
-    # Check metrics are not empty
-    dataset_metrics = metrics[dataset_name]
-
-    # Check if metrics are within valid range (0 to 1)
-    for metric_name, metric_value in dataset_metrics.items():
-        if not np.isnan(metric_value):
-            assert 0 <= metric_value <= 1, f"Metric {metric_name} outside valid range: {metric_value}"
-
-    # Check for specific NDCG@5 output in stdout
-    assert f"NDCG@5 for {model_class} on {dataset_name}:" in result.stdout
+    # Check for specific nDCG@5 output in stdout
+    assert f"nDCG@5 for {model_class} on {dataset_name}:" in result.stdout

--- a/tests/cli/test_evaluate_retriever.py
+++ b/tests/cli/test_evaluate_retriever.py
@@ -28,9 +28,9 @@ def cli_runner():
     return CliRunner()
 
 
-def test_evaluate_retriever_e2e(cli_runner, output_dir):
+def test_evaluate_retriever(cli_runner, output_dir):
     """
-    End-to-end test for evaluate_retriever command using a dummy dataset and model.
+    CLI test for the `evaluate_retriever` command using a dummy dataset and model.
     """
     # Arrange
     dataset_name = "vidore/syntheticDocQA_dummy"

--- a/tests/evaluation/test_eval_manager.py
+++ b/tests/evaluation/test_eval_manager.py
@@ -92,7 +92,7 @@ class TestEvalManagerInitialization(TestEvalManagerBase):
         results = ViDoReBenchmarkResults(
             metadata=MetadataModel(
                 timestamp=datetime.now(),
-                vidore_benchmark_hash="1234567890abcdef",
+                vidore_benchmark_version="0.0.1.dev7+g462dc4f.d20241102",
             ),
             metrics={
                 "dataset1": MetricsModel(ndcg_at_1=0.8, ndcg_at_3=0.7),

--- a/tests/evaluation/test_eval_manager.py
+++ b/tests/evaluation/test_eval_manager.py
@@ -6,7 +6,7 @@ import pytest
 from pandas.testing import assert_frame_equal
 
 from vidore_benchmark.evaluation.eval_manager import EvalManager
-from vidore_benchmark.evaluation.interfaces import MetadataModel, MetricsModel, ViDoReBenchmarkResults
+from vidore_benchmark.evaluation.interfaces import MetadataModel, ViDoReBenchmarkResults
 
 
 class TestEvalManagerBase:
@@ -95,8 +95,8 @@ class TestEvalManagerInitialization(TestEvalManagerBase):
                 vidore_benchmark_version="0.0.1.dev7+g462dc4f.d20241102",
             ),
             metrics={
-                "dataset1": MetricsModel(ndcg_at_1=0.8, ndcg_at_3=0.7),
-                "dataset2": MetricsModel(ndcg_at_1=0.9, ndcg_at_3=0.85),
+                "dataset1": {"ndcg_at_1": 0.8, "ndcg_at_3": 0.7},
+                "dataset2": {"ndcg_at_1": 0.9, "ndcg_at_3": 0.85},
             },
         )
         eval_manager = EvalManager.from_vidore_results(results, model_name="test_model")

--- a/tests/evaluation/test_eval_manager.py
+++ b/tests/evaluation/test_eval_manager.py
@@ -1,0 +1,154 @@
+import json
+from datetime import datetime
+
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from vidore_benchmark.evaluation.eval_manager import EvalManager
+from vidore_benchmark.evaluation.interfaces import MetadataModel, MetricsModel, ViDoReBenchmarkResults
+
+
+class TestEvalManagerBase:
+    @pytest.fixture
+    def sample_data(self):
+        return {
+            "model1": pd.Series(
+                {
+                    ("dataset1", "metric1"): 0.8,
+                    ("dataset1", "metric2"): 0.7,
+                    ("dataset2", "metric1"): 0.6,
+                }
+            ),
+            "model2": pd.Series(
+                {
+                    ("dataset1", "metric1"): 0.9,
+                    ("dataset1", "metric2"): 0.85,
+                    ("dataset2", "metric1"): 0.75,
+                }
+            ),
+        }
+
+    @pytest.fixture
+    def sample_json_path(self, tmp_path, sample_data):
+        data = {"dataset1": {"metric1": 0.8, "metric2": 0.7}, "dataset2": {"metric1": 0.6}}
+        json_path = tmp_path / "model1.json"
+        with open(json_path, "w") as f:
+            json.dump(data, f)
+        return json_path
+
+    @pytest.fixture
+    def eval_manager(self, sample_data):
+        return EvalManager.from_dict(sample_data)
+
+
+class TestEvalManagerInitialization(TestEvalManagerBase):
+    def test_init_empty(self):
+        eval_manager = EvalManager()
+        assert eval_manager.data.empty
+
+    def test_from_dict(self, sample_data):
+        eval_manager = EvalManager.from_dict(sample_data)
+        assert not eval_manager.data.empty
+        assert list(eval_manager.models) == ["model1", "model2"]
+        assert list(eval_manager.datasets) == ["dataset1", "dataset2"]
+
+    def test_from_json(self, sample_json_path):
+        eval_manager = EvalManager.from_json(sample_json_path)
+        assert not eval_manager.data.empty
+        assert list(eval_manager.models) == ["model1"]
+
+    def test_from_multiple_json(self, tmp_path, sample_data):
+        data1 = {"dataset1": {"metric1": 0.8, "metric2": 0.7}}
+        data2 = {"dataset1": {"metric1": 0.9, "metric2": 0.85}}
+
+        path1 = tmp_path / "model1.json"
+        path2 = tmp_path / "model2.json"
+
+        with open(path1, "w") as f:
+            json.dump(data1, f)
+        with open(path2, "w") as f:
+            json.dump(data2, f)
+
+        eval_manager = EvalManager.from_multiple_json([path1, path2])
+        assert len(eval_manager.models) == 2
+
+    def test_from_dir(self, tmp_path, sample_data):
+        data1 = {"dataset1": {"metric1": 0.8, "metric2": 0.7}}
+        data2 = {"dataset1": {"metric1": 0.9, "metric2": 0.85}}
+
+        path1 = tmp_path / "model1.json"
+        path2 = tmp_path / "model2.json"
+
+        with open(path1, "w") as f:
+            json.dump(data1, f)
+        with open(path2, "w") as f:
+            json.dump(data2, f)
+
+        eval_manager = EvalManager.from_dir(tmp_path)
+        assert len(eval_manager.models) == 2
+
+    def test_from_vidore_results(self):
+        results = ViDoReBenchmarkResults(
+            metadata=MetadataModel(
+                timestamp=datetime.now(),
+                vidore_benchmark_hash="1234567890abcdef",
+            ),
+            metrics={
+                "dataset1": MetricsModel(ndcg_at_1=0.8, ndcg_at_3=0.7),
+                "dataset2": MetricsModel(ndcg_at_1=0.9, ndcg_at_3=0.85),
+            },
+        )
+        eval_manager = EvalManager.from_vidore_results(results, model_name="test_model")
+        assert not eval_manager.data.empty
+        assert set(eval_manager.datasets) == {"dataset1", "dataset2"}
+
+
+class TestEvalManagerDataAccess(TestEvalManagerBase):
+    def test_property_accessors(self, eval_manager):
+        assert list(eval_manager.models) == ["model1", "model2"]
+        assert list(eval_manager.datasets) == ["dataset1", "dataset2"]
+        assert set(eval_manager.metrics) == {"metric1", "metric2"}
+
+    def test_get_df_for_model(self, eval_manager):
+        df = eval_manager.get_df_for_model("model1")
+        assert df.index.tolist() == ["model1"]
+
+        with pytest.raises(ValueError):
+            eval_manager.get_df_for_model("nonexistent_model")
+
+    def test_get_df_for_dataset(self, eval_manager):
+        df = eval_manager.get_df_for_dataset("dataset1")
+        assert set(df.columns.get_level_values(0)) == {"dataset1"}
+
+        with pytest.raises(ValueError):
+            eval_manager.get_df_for_dataset("nonexistent_dataset")
+
+    def test_get_df_for_metric(self, eval_manager):
+        df = eval_manager.get_df_for_metric("metric1")
+        assert set(df.columns.get_level_values(1)) == {"metric1"}
+
+        with pytest.raises(ValueError):
+            eval_manager.get_df_for_metric("nonexistent_metric")
+
+
+class TestEvalManagerOperations(TestEvalManagerBase):
+    def test_sort_methods(self, eval_manager):
+        sorted_by_dataset = eval_manager.sort_by_dataset()
+        assert list(sorted_by_dataset.datasets) == sorted(eval_manager.datasets)
+
+        sorted_by_metric = eval_manager.sort_by_metric()
+        assert list(sorted_by_metric.metrics) == sorted(eval_manager.metrics)
+
+    def test_melt(self, eval_manager):
+        melted = eval_manager.melted
+        assert set(melted.columns) == {"dataset", "metric", "model", "score"}
+        assert len(melted) == 6
+
+    def test_to_csv(self, eval_manager, tmp_path):
+        csv_path = tmp_path / "test_output.csv"
+        eval_manager.to_csv(csv_path)
+        assert csv_path.exists()
+
+        loaded_manager = EvalManager.from_csv(csv_path)
+        assert_frame_equal(loaded_manager.data, eval_manager.data)

--- a/tests/evaluation/test_inferfaces.py
+++ b/tests/evaluation/test_inferfaces.py
@@ -2,22 +2,10 @@ from datetime import datetime
 
 import pytest
 
-from vidore_benchmark.evaluation.interfaces import MetadataModel, MetricsModel, ViDoReBenchmarkResults
+from vidore_benchmark.evaluation.interfaces import MetadataModel, ViDoReBenchmarkResults
 
 
 class TestViDoReBenchmarkCreation:
-    def test_metrics_model_creation(self):
-        """Test basic creation of MetricsModel with valid data"""
-        metrics = MetricsModel(
-            ndcg_at_1=0.5,
-            ndcg_at_3=0.7,
-            map_at_1=0.4,
-        )
-
-        assert metrics.ndcg_at_1 == 0.5
-        assert metrics.ndcg_at_3 == 0.7
-        assert metrics.map_at_1 == 0.4
-
     def test_metadata_creation(self):
         """Test creation of Metadata with required fields"""
         current_time = datetime.now()
@@ -50,14 +38,14 @@ class TestViDoReBenchmarkCreation:
                 vidore_benchmark_version="0.0.1.dev7+g462dc4f.d20241102",
             ),
             metrics={
-                "test_dataset": MetricsModel(ndcg_at_1=0.5, ndcg_at_3=0.7),
+                "test_dataset": {"ndcg_at_1": 0.5, "ndcg_at_3": 0.7},
             },
         )
 
         assert results.metadata.timestamp == current_time
         assert results.metadata.vidore_benchmark_version == "0.0.1.dev7+g462dc4f.d20241102"
-        assert results.metrics["test_dataset"].ndcg_at_1 == 0.5
-        assert results.metrics["test_dataset"].ndcg_at_3 == 0.7
+        assert results.metrics["test_dataset"]["ndcg_at_1"] == 0.5
+        assert results.metrics["test_dataset"]["ndcg_at_3"] == 0.7
 
 
 class TestViDoReBenchmarkMerging:
@@ -68,7 +56,7 @@ class TestViDoReBenchmarkMerging:
                 timestamp=datetime(2024, 1, 1),
                 vidore_benchmark_version="0.0.1-dev1",
             ),
-            metrics={"benchmark1": MetricsModel(ndcg_at_1=0.5)},
+            metrics={"benchmark1": {"ndcg_at_1": 0.5}},
         )
 
         result2 = ViDoReBenchmarkResults(
@@ -76,7 +64,7 @@ class TestViDoReBenchmarkMerging:
                 timestamp=datetime(2024, 2, 1),
                 vidore_benchmark_version="0.0.1-dev2",
             ),
-            metrics={"benchmark2": MetricsModel(ndcg_at_1=0.7)},
+            metrics={"benchmark2": {"ndcg_at_1": 0.7}},
         )
 
         merged = ViDoReBenchmarkResults.merge([result1, result2])
@@ -87,8 +75,8 @@ class TestViDoReBenchmarkMerging:
 
         # Check that metrics from both results are present
         assert len(merged.metrics) == 2
-        assert merged.metrics["benchmark1"].ndcg_at_1 == 0.5
-        assert merged.metrics["benchmark2"].ndcg_at_1 == 0.7
+        assert merged.metrics["benchmark1"]["ndcg_at_1"] == 0.5
+        assert merged.metrics["benchmark2"]["ndcg_at_1"] == 0.7
 
     def test_merge_duplicate_keys_error(self):
         """Test that merging results with duplicate benchmark keys raises ValueError."""
@@ -98,8 +86,8 @@ class TestViDoReBenchmarkMerging:
                 vidore_benchmark_version="0.0.1-dev1",
             ),
             metrics={
-                "benchmark1": MetricsModel(ndcg_at_1=0.5),
-                "benchmark2": MetricsModel(ndcg_at_1=0.6),
+                "benchmark1": {"ndcg_at_1": 0.5},
+                "benchmark2": {"ndcg_at_1": 0.6},
             },
         )
 
@@ -109,8 +97,8 @@ class TestViDoReBenchmarkMerging:
                 vidore_benchmark_version="0.0.1-dev2",
             ),
             metrics={
-                "benchmark2": MetricsModel(ndcg_at_1=0.7),  # Duplicate key with result1
-                "benchmark3": MetricsModel(ndcg_at_1=0.8),
+                "benchmark2": {"ndcg_at_1": 0.7},  # Duplicate key with result1
+                "benchmark3": {"ndcg_at_1": 0.8},
             },
         )
 

--- a/tests/evaluation/test_inferfaces.py
+++ b/tests/evaluation/test_inferfaces.py
@@ -1,56 +1,102 @@
 from datetime import datetime
 
-from vidore_benchmark.evaluation.interfaces import Metadata, MetricsModel, ViDoReBenchmarkResults
+import pytest
+
+from vidore_benchmark.evaluation.interfaces import MetadataModel, MetricsModel, ViDoReBenchmarkResults
 
 
-def test_metrics_model_creation():
-    """Test basic creation of MetricsModel with valid data"""
-    metrics = MetricsModel(
-        ndcg_at_1=0.5,
-        ndcg_at_3=0.7,
-        map_at_1=0.4,
-    )
+class TestViDoReBenchmarkCreation:
+    def test_metrics_model_creation(self):
+        """Test basic creation of MetricsModel with valid data"""
+        metrics = MetricsModel(
+            ndcg_at_1=0.5,
+            ndcg_at_3=0.7,
+            map_at_1=0.4,
+        )
 
-    assert metrics.ndcg_at_1 == 0.5
-    assert metrics.ndcg_at_3 == 0.7
-    assert metrics.map_at_1 == 0.4
+        assert metrics.ndcg_at_1 == 0.5
+        assert metrics.ndcg_at_3 == 0.7
+        assert metrics.map_at_1 == 0.4
 
+    def test_metadata_creation(self):
+        """Test creation of Metadata with required fields"""
+        current_time = datetime.now()
+        metadata = MetadataModel(timestamp=current_time, vidore_benchmark_hash="1234567890abcdef")
 
-def test_metadata_creation():
-    """Test creation of Metadata with required fields"""
-    current_time = datetime.now()
-    metadata = Metadata(timestamp=current_time, vidore_benchmark_hash="1234567890abcdef")
+        assert metadata.timestamp == current_time
+        assert metadata.vidore_benchmark_hash == "1234567890abcdef"
 
-    assert metadata.timestamp == current_time
-    assert metadata.vidore_benchmark_hash == "1234567890abcdef"
-
-
-def test_metadata_extra_fields():
-    """Test that Metadata allows extra fields"""
-    metadata = Metadata(
-        timestamp=datetime.now(),
-        vidore_benchmark_hash="1234567890abcdef",
-        extra_field="extra_value",
-    )
-
-    assert metadata.extra_field == "extra_value"
-
-
-def test_vidore_benchmark_results_creation():
-    """Test creation of complete ViDoReBenchmarkResults"""
-    current_time = datetime.now()
-
-    results = ViDoReBenchmarkResults(
-        metadata=Metadata(
-            timestamp=current_time,
+    def test_metadata_extra_fields(self):
+        """Test that Metadata allows extra fields"""
+        metadata = MetadataModel(
+            timestamp=datetime.now(),
             vidore_benchmark_hash="1234567890abcdef",
-        ),
-        metrics={
-            "test_dataset": MetricsModel(ndcg_at_1=0.5, ndcg_at_3=0.7),
-        },
-    )
+            extra_field="extra_value",
+        )
 
-    assert results.metadata.timestamp == current_time
-    assert results.metadata.vidore_benchmark_hash == "1234567890abcdef"
-    assert results.metrics["test_dataset"].ndcg_at_1 == 0.5
-    assert results.metrics["test_dataset"].ndcg_at_3 == 0.7
+        assert metadata.extra_field == "extra_value"
+
+    def test_vidore_benchmark_results_creation(self):
+        """Test creation of complete ViDoReBenchmarkResults"""
+        current_time = datetime.now()
+        results = ViDoReBenchmarkResults(
+            metadata=MetadataModel(
+                timestamp=current_time,
+                vidore_benchmark_hash="1234567890abcdef",
+            ),
+            metrics={
+                "test_dataset": MetricsModel(ndcg_at_1=0.5, ndcg_at_3=0.7),
+            },
+        )
+
+        assert results.metadata.timestamp == current_time
+        assert results.metadata.vidore_benchmark_hash == "1234567890abcdef"
+        assert results.metrics["test_dataset"].ndcg_at_1 == 0.5
+        assert results.metrics["test_dataset"].ndcg_at_3 == 0.7
+
+
+class TestViDoReBenchmarkMerging:
+    def test_merge_results(self):
+        """Test basic merging of two results with different benchmarks."""
+        result1 = ViDoReBenchmarkResults(
+            metadata=MetadataModel(timestamp=datetime(2024, 1, 1), vidore_benchmark_hash="hash1"),
+            metrics={"benchmark1": MetricsModel(ndcg_at_1=0.5)},
+        )
+
+        result2 = ViDoReBenchmarkResults(
+            metadata=MetadataModel(timestamp=datetime(2024, 2, 1), vidore_benchmark_hash="hash2"),
+            metrics={"benchmark2": MetricsModel(ndcg_at_1=0.7)},
+        )
+
+        merged = ViDoReBenchmarkResults.merge([result1, result2])
+
+        # Check that metadata comes from the latest result
+        assert merged.metadata.timestamp == datetime(2024, 2, 1)
+        assert merged.metadata.vidore_benchmark_hash == "hash2"
+
+        # Check that metrics from both results are present
+        assert len(merged.metrics) == 2
+        assert merged.metrics["benchmark1"].ndcg_at_1 == 0.5
+        assert merged.metrics["benchmark2"].ndcg_at_1 == 0.7
+
+    def test_merge_duplicate_keys_error(self):
+        """Test that merging results with duplicate benchmark keys raises ValueError."""
+        result1 = ViDoReBenchmarkResults(
+            metadata=MetadataModel(timestamp=datetime(2024, 1, 1), vidore_benchmark_hash="hash1"),
+            metrics={
+                "benchmark1": MetricsModel(ndcg_at_1=0.5),
+                "benchmark2": MetricsModel(ndcg_at_1=0.6),
+            },
+        )
+
+        result2 = ViDoReBenchmarkResults(
+            metadata=MetadataModel(timestamp=datetime(2024, 2, 1), vidore_benchmark_hash="hash2"),
+            metrics={
+                "benchmark2": MetricsModel(ndcg_at_1=0.7),  # Duplicate key with result1
+                "benchmark3": MetricsModel(ndcg_at_1=0.8),
+            },
+        )
+
+        # Should raise ValueError due to duplicate 'benchmark2' key
+        with pytest.raises(ValueError, match="Duplicate dataset keys found in the input results"):
+            ViDoReBenchmarkResults.merge([result1, result2])

--- a/tests/evaluation/test_inferfaces.py
+++ b/tests/evaluation/test_inferfaces.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+
+from vidore_benchmark.evaluation.interfaces import Metadata, MetricsModel, ViDoReBenchmarkResults
+
+
+def test_metrics_model_creation():
+    """Test basic creation of MetricsModel with valid data"""
+    metrics = MetricsModel(
+        ndcg_at_1=0.5,
+        ndcg_at_3=0.7,
+        map_at_1=0.4,
+    )
+
+    assert metrics.ndcg_at_1 == 0.5
+    assert metrics.ndcg_at_3 == 0.7
+    assert metrics.map_at_1 == 0.4
+
+
+def test_metadata_creation():
+    """Test creation of Metadata with required fields"""
+    current_time = datetime.now()
+    metadata = Metadata(timestamp=current_time, vidore_benchmark_hash="1234567890abcdef")
+
+    assert metadata.timestamp == current_time
+    assert metadata.vidore_benchmark_hash == "1234567890abcdef"
+
+
+def test_metadata_extra_fields():
+    """Test that Metadata allows extra fields"""
+    metadata = Metadata(
+        timestamp=datetime.now(),
+        vidore_benchmark_hash="1234567890abcdef",
+        extra_field="extra_value",
+    )
+
+    assert metadata.extra_field == "extra_value"
+
+
+def test_vidore_benchmark_results_creation():
+    """Test creation of complete ViDoReBenchmarkResults"""
+    current_time = datetime.now()
+
+    results = ViDoReBenchmarkResults(
+        metadata=Metadata(
+            timestamp=current_time,
+            vidore_benchmark_hash="1234567890abcdef",
+        ),
+        metrics={
+            "test_dataset": MetricsModel(ndcg_at_1=0.5, ndcg_at_3=0.7),
+        },
+    )
+
+    assert results.metadata.timestamp == current_time
+    assert results.metadata.vidore_benchmark_hash == "1234567890abcdef"
+    assert results.metrics["test_dataset"].ndcg_at_1 == 0.5
+    assert results.metrics["test_dataset"].ndcg_at_3 == 0.7

--- a/tests/evaluation/test_inferfaces.py
+++ b/tests/evaluation/test_inferfaces.py
@@ -21,19 +21,24 @@ class TestViDoReBenchmarkCreation:
     def test_metadata_creation(self):
         """Test creation of Metadata with required fields"""
         current_time = datetime.now()
-        metadata = MetadataModel(timestamp=current_time, vidore_benchmark_hash="1234567890abcdef")
+
+        metadata = MetadataModel(
+            timestamp=current_time,
+            vidore_benchmark_version="0.0.1.dev7+g462dc4f.d20241102",
+        )
 
         assert metadata.timestamp == current_time
-        assert metadata.vidore_benchmark_hash == "1234567890abcdef"
+        assert metadata.vidore_benchmark_version == "0.0.1.dev7+g462dc4f.d20241102"
 
     def test_metadata_extra_fields(self):
         """Test that Metadata allows extra fields"""
         metadata = MetadataModel(
             timestamp=datetime.now(),
-            vidore_benchmark_hash="1234567890abcdef",
+            vidore_benchmark_version="0.0.1.dev7+g462dc4f.d20241102",
             extra_field="extra_value",
         )
 
+        assert hasattr(metadata, "extra_field")
         assert metadata.extra_field == "extra_value"
 
     def test_vidore_benchmark_results_creation(self):
@@ -42,7 +47,7 @@ class TestViDoReBenchmarkCreation:
         results = ViDoReBenchmarkResults(
             metadata=MetadataModel(
                 timestamp=current_time,
-                vidore_benchmark_hash="1234567890abcdef",
+                vidore_benchmark_version="0.0.1.dev7+g462dc4f.d20241102",
             ),
             metrics={
                 "test_dataset": MetricsModel(ndcg_at_1=0.5, ndcg_at_3=0.7),
@@ -50,7 +55,7 @@ class TestViDoReBenchmarkCreation:
         )
 
         assert results.metadata.timestamp == current_time
-        assert results.metadata.vidore_benchmark_hash == "1234567890abcdef"
+        assert results.metadata.vidore_benchmark_version == "0.0.1.dev7+g462dc4f.d20241102"
         assert results.metrics["test_dataset"].ndcg_at_1 == 0.5
         assert results.metrics["test_dataset"].ndcg_at_3 == 0.7
 
@@ -59,12 +64,18 @@ class TestViDoReBenchmarkMerging:
     def test_merge_results(self):
         """Test basic merging of two results with different benchmarks."""
         result1 = ViDoReBenchmarkResults(
-            metadata=MetadataModel(timestamp=datetime(2024, 1, 1), vidore_benchmark_hash="hash1"),
+            metadata=MetadataModel(
+                timestamp=datetime(2024, 1, 1),
+                vidore_benchmark_version="0.0.1-dev1",
+            ),
             metrics={"benchmark1": MetricsModel(ndcg_at_1=0.5)},
         )
 
         result2 = ViDoReBenchmarkResults(
-            metadata=MetadataModel(timestamp=datetime(2024, 2, 1), vidore_benchmark_hash="hash2"),
+            metadata=MetadataModel(
+                timestamp=datetime(2024, 2, 1),
+                vidore_benchmark_version="0.0.1-dev2",
+            ),
             metrics={"benchmark2": MetricsModel(ndcg_at_1=0.7)},
         )
 
@@ -72,7 +83,7 @@ class TestViDoReBenchmarkMerging:
 
         # Check that metadata comes from the latest result
         assert merged.metadata.timestamp == datetime(2024, 2, 1)
-        assert merged.metadata.vidore_benchmark_hash == "hash2"
+        assert merged.metadata.vidore_benchmark_version == "0.0.1-dev2"
 
         # Check that metrics from both results are present
         assert len(merged.metrics) == 2
@@ -82,7 +93,10 @@ class TestViDoReBenchmarkMerging:
     def test_merge_duplicate_keys_error(self):
         """Test that merging results with duplicate benchmark keys raises ValueError."""
         result1 = ViDoReBenchmarkResults(
-            metadata=MetadataModel(timestamp=datetime(2024, 1, 1), vidore_benchmark_hash="hash1"),
+            metadata=MetadataModel(
+                timestamp=datetime(2024, 1, 1),
+                vidore_benchmark_version="0.0.1-dev1",
+            ),
             metrics={
                 "benchmark1": MetricsModel(ndcg_at_1=0.5),
                 "benchmark2": MetricsModel(ndcg_at_1=0.6),
@@ -90,7 +104,10 @@ class TestViDoReBenchmarkMerging:
         )
 
         result2 = ViDoReBenchmarkResults(
-            metadata=MetadataModel(timestamp=datetime(2024, 2, 1), vidore_benchmark_hash="hash2"),
+            metadata=MetadataModel(
+                timestamp=datetime(2024, 2, 1),
+                vidore_benchmark_version="0.0.1-dev2",
+            ),
             metrics={
                 "benchmark2": MetricsModel(ndcg_at_1=0.7),  # Duplicate key with result1
                 "benchmark3": MetricsModel(ndcg_at_1=0.8),

--- a/tests/retrievers/test_dummy_retriever.py
+++ b/tests/retrievers/test_dummy_retriever.py
@@ -12,19 +12,16 @@ def retriever() -> Generator[DummyRetriever, None, None]:
     tear_down_torch()
 
 
-@pytest.mark.slow
 def test_forward_queries(retriever: DummyRetriever, queries_fixture):
     embeddings_queries = retriever.forward_queries(queries_fixture, batch_size=1)
     assert len(embeddings_queries) == len(queries_fixture)
 
 
-@pytest.mark.slow
 def test_forward_documents(retriever: DummyRetriever, image_passage_fixture):
     embeddings_docs = retriever.forward_passages(image_passage_fixture, batch_size=1)
     assert len(embeddings_docs) == len(image_passage_fixture)
 
 
-@pytest.mark.slow
 def test_get_scores(
     retriever: DummyRetriever,
     query_single_vector_embeddings_fixture,


### PR DESCRIPTION
## Description

Add metadata field to benchmark results + use Pydantic.

**Note:** Once merged, [this PR on vidore-leaderboard](https://huggingface.co/spaces/vidore/vidore-leaderboard/discussions/2) should be reviewed and merged too.

## Features

### Added

- Add Pydantic models for storing the ViDoRe benchmark results and metadata (includes package hash)

## Tests

### Example of a result JSON output

**Input command:**

```bash
vidore-benchmark evaluate-retriever \
    --model-class dummy_retriever \
    --dataset-name vidore/syntheticDocQA_dummy \
    --split test
```

`dummy_retriever_all_metrics.json`

```json
{
    "metadata": {
        "timestamp": "2024-12-01T22:17:31.271300",
        "vidore_benchmark_version": "4.0.3.dev7+g462dc4f.d20241102"
    },
    "metrics": {
        "vidore/syntheticDocQA_dummy": {
            "ndcg_at_1": 0.5,
            "ndcg_at_3": 0.5,
            "ndcg_at_5": 0.71534,
            "ndcg_at_10": 0.71534,
            "ndcg_at_20": 0.71534,
            "ndcg_at_50": 0.71534,
            "ndcg_at_100": 0.71534,
            "map_at_1": 0.5,
            "map_at_3": 0.5,
            "map_at_5": 0.625,
            "map_at_10": 0.625,
            "map_at_20": 0.625,
            "map_at_50": 0.625,
            "map_at_100": 0.625,
            "recall_at_1": 0.5,
            "recall_at_3": 0.5,
            "recall_at_5": 1.0,
            "recall_at_10": 1.0,
            "recall_at_20": 1.0,
            "recall_at_50": 1.0,
            "recall_at_100": 1.0,
            "precision_at_1": 0.5,
            "precision_at_3": 0.16667,
            "precision_at_5": 0.2,
            "precision_at_10": 0.1,
            "precision_at_20": 0.05,
            "precision_at_50": 0.02,
            "precision_at_100": 0.01,
            "mrr_at_1": 0.5,
            "mrr_at_3": 0.5,
            "mrr_at_5": 0.625,
            "mrr_at_10": 0.625,
            "mrr_at_20": 0.625,
            "mrr_at_50": 0.625,
            "mrr_at_100": 0.625,
            "naucs_at_1_max": 1.0,
            "naucs_at_1_std": -1.0,
            "naucs_at_1_diff1": 1.0,
            "naucs_at_3_max": 1.0,
            "naucs_at_3_std": -1.0000000000000002,
            "naucs_at_3_diff1": 1.0,
            "naucs_at_5_max": null,
            "naucs_at_5_std": null,
            "naucs_at_5_diff1": null,
            "naucs_at_10_max": null,
            "naucs_at_10_std": null,
            "naucs_at_10_diff1": null,
            "naucs_at_20_max": null,
            "naucs_at_20_std": null,
            "naucs_at_20_diff1": null,
            "naucs_at_50_max": 1.0,
            "naucs_at_50_std": 1.0,
            "naucs_at_50_diff1": 1.0,
            "naucs_at_100_max": 1.0,
            "naucs_at_100_std": 1.0,
            "naucs_at_100_diff1": 1.0
        }
    }
}
```

### Check metric consistency wrt HEAD of `main` (f1f40c1e610fbe41d348d94c8faad6ce0bdb2131)

```bash
vidore-benchmark evaluate-retriever \
    --model-class colpali \
    --model-name vidore/colpali-v1.2 \
    --dataset-name vidore/shiftproject_test \
    --split test
```

**Results from HEAD:**

```json
{
    "vidore/shiftproject_test": {
        "ndcg_at_1": 0.62,
        "ndcg_at_3": 0.75726,
        "ndcg_at_5": 0.78222,
        "ndcg_at_10": 0.79496,
        "ndcg_at_20": 0.80225,
        "ndcg_at_50": 0.80407,
        "ndcg_at_100": 0.80407,
        "map_at_1": 0.62,
        "map_at_3": 0.725,
        "map_at_5": 0.739,
        "map_at_10": 0.74414,
        "map_at_20": 0.74599,
        "map_at_50": 0.74622,
        "map_at_100": 0.74622,
        "recall_at_1": 0.62,
        "recall_at_3": 0.85,
        "recall_at_5": 0.91,
        "recall_at_10": 0.95,
        "recall_at_20": 0.98,
        "recall_at_50": 0.99,
        "recall_at_100": 0.99,
        "precision_at_1": 0.62,
        "precision_at_3": 0.28333,
        "precision_at_5": 0.182,
        "precision_at_10": 0.095,
        "precision_at_20": 0.049,
        "precision_at_50": 0.0198,
        "precision_at_100": 0.0099,
        "mrr_at_1": 0.65,
        "mrr_at_3": 0.7366666666666667,
        "mrr_at_5": 0.7531666666666667,
        "mrr_at_10": 0.7600396825396826,
        "mrr_at_20": 0.7613095238095237,
        "mrr_at_50": 0.7615367965367965,
        "mrr_at_100": 0.7615367965367965,
        "naucs_at_1_max": 0.011383564594037348,
        "naucs_at_1_std": -0.3069255145678863,
        "naucs_at_1_diff1": 0.6713226471402637,
        "naucs_at_3_max": -0.09118125610152811,
        "naucs_at_3_std": -0.45034168564920113,
        "naucs_at_3_diff1": 0.4871461112918982,
        "naucs_at_5_max": -0.42047930283224205,
        "naucs_at_5_std": -0.9665421724245231,
        "naucs_at_5_diff1": 0.5389563232700478,
        "naucs_at_10_max": -0.4455648926237065,
        "naucs_at_10_std": -1.190943043884201,
        "naucs_at_10_diff1": 0.7343604108310002,
        "naucs_at_20_max": -0.6909430438842098,
        "naucs_at_20_std": -1.1517273576096962,
        "naucs_at_20_diff1": 0.861111111111116,
        "naucs_at_50_max": 0.35807656395892007,
        "naucs_at_50_std": -0.5634920634920583,
        "naucs_at_50_diff1": 0.7222222222222041,
        "naucs_at_100_max": 0.35807656395892007,
        "naucs_at_100_std": -0.5634920634920583,
        "naucs_at_100_diff1": 0.7222222222222041
    }
}
```

**Results with this PR branch:**

```json
{
    "metadata": {
        "timestamp": "2024-12-02T15:57:02.316118",
        "vidore_benchmark_version": "4.0.3.dev56+g6611681"
    },
    "metrics": {
        "vidore/shiftproject_test": {
            "ndcg_at_1": 0.62,
            "ndcg_at_3": 0.75726,
            "ndcg_at_5": 0.78222,
            "ndcg_at_10": 0.79496,
            "ndcg_at_20": 0.80225,
            "ndcg_at_50": 0.80407,
            "ndcg_at_100": 0.80407,
            "map_at_1": 0.62,
            "map_at_3": 0.725,
            "map_at_5": 0.739,
            "map_at_10": 0.74414,
            "map_at_20": 0.74599,
            "map_at_50": 0.74622,
            "map_at_100": 0.74622,
            "recall_at_1": 0.62,
            "recall_at_3": 0.85,
            "recall_at_5": 0.91,
            "recall_at_10": 0.95,
            "recall_at_20": 0.98,
            "recall_at_50": 0.99,
            "recall_at_100": 0.99,
            "precision_at_1": 0.62,
            "precision_at_3": 0.28333,
            "precision_at_5": 0.182,
            "precision_at_10": 0.095,
            "precision_at_20": 0.049,
            "precision_at_50": 0.0198,
            "precision_at_100": 0.0099,
            "mrr_at_1": 0.65,
            "mrr_at_3": 0.7366666666666667,
            "mrr_at_5": 0.7531666666666667,
            "mrr_at_10": 0.7600396825396826,
            "mrr_at_20": 0.7613095238095237,
            "mrr_at_50": 0.7615367965367965,
            "mrr_at_100": 0.7615367965367965,
            "naucs_at_1_max": 0.011383564594037348,
            "naucs_at_1_std": -0.3069255145678863,
            "naucs_at_1_diff1": 0.6713226471402637,
            "naucs_at_3_max": -0.09118125610152811,
            "naucs_at_3_std": -0.45034168564920113,
            "naucs_at_3_diff1": 0.4871461112918982,
            "naucs_at_5_max": -0.42047930283224205,
            "naucs_at_5_std": -0.9665421724245231,
            "naucs_at_5_diff1": 0.5389563232700478,
            "naucs_at_10_max": -0.4455648926237065,
            "naucs_at_10_std": -1.190943043884201,
            "naucs_at_10_diff1": 0.7343604108310002,
            "naucs_at_20_max": -0.6909430438842098,
            "naucs_at_20_std": -1.1517273576096962,
            "naucs_at_20_diff1": 0.861111111111116,
            "naucs_at_50_max": 0.35807656395892007,
            "naucs_at_50_std": -0.5634920634920583,
            "naucs_at_50_diff1": 0.7222222222222041,
            "naucs_at_100_max": 0.35807656395892007,
            "naucs_at_100_std": -0.5634920634920583,
            "naucs_at_100_diff1": 0.7222222222222041
        }
    }
}
```

No diff in the metrics!

## Next steps: ViDoRe Leaderboard

Once merged, the following PR for the `vidore-leaderboard` space should be merged as well: https://huggingface.co/spaces/vidore/vidore-leaderboard/discussions/2.

**Test:**

<img width="2396" alt="Screenshot 2024-12-01 at 22 42 50" src="https://github.com/user-attachments/assets/8e44883b-8c2a-463b-83b6-9a678aec7168">
