### PR TITLE
Move and rename paper reproduction requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,6 @@ Or if you want to evaluate all the off-the-shelf retrievers:
 pip install "vidore-benchmark[all-retrievers]"
 ```
 
-Finally, if you are willing to reproduce the results from the ColPali paper, you should clone the repository, checkout to the `3.3.0` tag or below, and use the `requirements-dev.txt` file to install the dependencies used at test time:
-
-```bash
-pip install -r requirements-dev.txt
-```
-
 ## Available retrievers
 
 The list of available retrievers can be found [here](https://github.com/illuin-tech/vidore-benchmark/tree/main/src/vidore_benchmark/retrievers). Read [this section](###Implement-your-own-retriever) to learn how to create, use, and evaluate your own retriever.
@@ -206,3 +200,5 @@ Authors: **Manuel Faysse**\*, **Hugues Sibille**\*, **Tony Wu**\*, Bilel Omrani,
       url={https://arxiv.org/abs/2407.01449}, 
 }
 ```
+
+If you want to reproduce the results from the ColPali paper, please read the [`REPRODUCIBILITY.md`](REPRODUCIBILITY.md) file for more information.

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -1,3 +1,26 @@
+# Paper reproduction instructions
+
+## Instructions
+
+If you are willing to reproduce the results from the ColPali paper, you should:
+
+- clone the repository
+- checkout to the `3.3.0` tag or below
+- create a new virtual environment
+- copy the list of package versions from this file to a `requirements-dev.txt` file
+- install the dependencies using the following command:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Then, you can run the CLI commands to evaluate the models and reproduce the results from the paper.
+
+## Package versions
+
+`requirements-dev.txt`:
+
+```
 accelerate==0.30.1
 aiofiles==23.2.1
 aiohttp==3.9.5
@@ -158,3 +181,4 @@ wcwidth==0.2.13
 websockets==11.0.3
 xxhash==3.4.1
 yarl==1.9.4
+```


### PR DESCRIPTION
## Description

Move paper reproduction requirements to remove GitHub security warnings.