### PR TITLE
Use processor scoring method when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ feat: add better soft dep handling + change `get_scores` signature + add `scorin
 - Rename `DSERetriever` into `DSEQwen2Retriever`
 - Speed up tests by using smaller inputs
 - [Breaking] Rename args in CLI script
+- When available, use `processor.get_scores` instead of custom scoring snippet
 
 ### Fixed
 


### PR DESCRIPTION
## Description

Addresses https://github.com/illuin-tech/vidore-benchmark/issues/61

## Features

### Changed

- When available, use `processor.get_scores` instead of custom scoring snippet