### PR TITLE
Fix typo when building package version in vidore results

### DIFF
--- a/src/vidore_benchmark/main.py
+++ b/src/vidore_benchmark/main.py
@@ -176,7 +176,7 @@ def evaluate_retriever(
             results = ViDoReBenchmarkResults(
                 metadata=MetadataModel(
                     timestamp=datetime.now(),
-                    vidore_benchmark_version=os.popen("git rev-parse HEAD").read().strip(),
+                    vidore_benchmark_version=version("vidore_benchmark"),
                 ),
                 metrics={dataset_name: metrics[dataset_name]},
             )


### PR DESCRIPTION
## Description

Fix typo when building package version in vidore results. The typo was introduced in https://github.com/illuin-tech/vidore-benchmark/pull/64.