### PR TITLE
Fix eval mode in vision_retriever

### DIFF
--- a/src/vidore_benchmark/retrievers/vision_retriever.py
+++ b/src/vidore_benchmark/retrievers/vision_retriever.py
@@ -27,6 +27,7 @@ class VisionRetriever(BaseVisionRetriever):
         super().__init__(use_visual_embedding=True)
 
         self.model = model
+        self.model.eval()
 
         self.processor = processor
         if not hasattr(self.processor, "process_images"):


### PR DESCRIPTION
Fix a bug in Vision retriever where we didn't run the model in eval() mode