### PR TITLE
Adding optional dataset_name arg to index() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ class MyCustomPipeline(BasePipeline):
         self.model_name = model_name
         # Initialize your model here
 
-    def index(self, corpus_ids, corpus_images, corpus_texts):
+    def index(self, corpus_ids, corpus_images, corpus_texts, dataset_name: str = None):
         # Indexing function to process corpus, should store anything
         # relevant as class attributes
         self.corpus_ids = corpus_ids

--- a/pipeline_implementations/jinav4_text_zerank2textual_pipeline.py
+++ b/pipeline_implementations/jinav4_text_zerank2textual_pipeline.py
@@ -257,7 +257,7 @@ class JinaV4TextZeRank2TextualPipeline(BasePipeline):
 
         return results
 
-    def index(self, corpus_ids: List[str], corpus_images: List[str], corpus_texts: List[str]) -> None:
+    def index(self, corpus_ids: List[str], corpus_images: List[str], corpus_texts: List[str], dataset_name: str = None) -> None:
         """
         Indexing step for the pipeline. For this implementation, we don't need to do
         anything here since we compute embeddings on the fly in the search method.

--- a/pipeline_implementations/jinav4_vision_jinavisualreranker_pipeline.py
+++ b/pipeline_implementations/jinav4_vision_jinavisualreranker_pipeline.py
@@ -301,7 +301,7 @@ class JinaV4VisionJinaVisualRerankerPipeline(BasePipeline):
 
         return results
 
-    def index(self, corpus_ids, corpus_images, corpus_texts):
+    def index(self, corpus_ids, corpus_images, corpus_texts, dataset_name: str = None):
         """
         Store corpus data for use in search().
 

--- a/pipeline_implementations/mxbai_edge_colbert_pipeline.py
+++ b/pipeline_implementations/mxbai_edge_colbert_pipeline.py
@@ -159,7 +159,7 @@ class MxbaiEdgeColbertPipeline(BasePipeline):
 
         return torch.cat(scores, dim=0)
 
-    def index(self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str]) -> None:
+    def index(self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str], dataset_name: str = None) -> None:
         """
         Indexing is performed on-the-fly in the retrieve method for this pipeline.
         This method is not used but must be implemented to satisfy the BasePipeline interface.

--- a/pipeline_implementations/nemotron_colembed_8b_v2.py
+++ b/pipeline_implementations/nemotron_colembed_8b_v2.py
@@ -297,7 +297,7 @@ class NemotronColEmbed8BPipeline(BasePipeline):
         self.batch_size = batch_size
         self.embedding_model = NemotronColEmbed8B(model_name=model_name, batch_size=batch_size)
 
-    def index(self, corpus_ids, corpus_images, corpus_texts):
+    def index(self, corpus_ids, corpus_images, corpus_texts, dataset_name = None):
         """
         Store corpus data for use in search().
 

--- a/pipeline_implementations/nemotron_embed_and_rerank_vl_v2.py
+++ b/pipeline_implementations/nemotron_embed_and_rerank_vl_v2.py
@@ -400,7 +400,7 @@ class NemotronEmbedRerankVLPipeline(BasePipeline):
                                         batch_size=ranker_batch_size,
                                         modality=self.modality)
         
-    def index(self, corpus_ids, corpus_images, corpus_texts):
+    def index(self, corpus_ids, corpus_images, corpus_texts, dataset_name = None):
         """
         Store corpus data for use in search().
 

--- a/pipeline_implementations/nemotron_embed_vl_v2.py
+++ b/pipeline_implementations/nemotron_embed_vl_v2.py
@@ -308,7 +308,7 @@ class NemotronEmbedVLPipeline(BasePipeline):
         self.batch_size = batch_size
         self.embedding_model = NemotronEmbedVL(model_name=model_name, batch_size=batch_size, modality=self.modality)
 
-    def index(self, corpus_ids, corpus_images, corpus_texts):
+    def index(self, corpus_ids, corpus_images, corpus_texts, dataset_name = None):
         """
         Store corpus data for use in search().
 

--- a/pipeline_implementations/qwen3_embedding_8b_pipeline.py
+++ b/pipeline_implementations/qwen3_embedding_8b_pipeline.py
@@ -178,7 +178,7 @@ class Qwen3Embedding8BPipeline(BasePipeline):
 
         return scores
 
-    def index(self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str]) -> None:
+    def index(self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str], dataset_name = None) -> None:
         """
         Index the corpus by embedding all texts and storing them in memory.
         The embeddings are stored in self.corpus_embeddings and the corresponding IDs and texts are stored

--- a/src/vidore_benchmark/cli/pipeline_evaluation.py
+++ b/src/vidore_benchmark/cli/pipeline_evaluation.py
@@ -217,6 +217,7 @@ def evaluate(
             corpus_images=corpus_images,
             corpus_texts=corpus_texts,
             qrels=qrels,
+            dataset_name=dataset_name,
             metrics=[
                 "ndcg_cut_1",
                 "ndcg_cut_5",
@@ -452,6 +453,7 @@ def evaluate_all(
                 corpus_images=corpus_images,
                 corpus_texts=corpus_texts,
                 qrels=qrels,
+                dataset_name=dataset_name,
                 metrics=[
                     "ndcg_cut_1",
                     "ndcg_cut_5",

--- a/src/vidore_benchmark/pipeline_evaluation/base_pipeline.py
+++ b/src/vidore_benchmark/pipeline_evaluation/base_pipeline.py
@@ -14,11 +14,9 @@ class BasePipeline(ABC):
     with their custom pipeline logic.
     """
 
-    def index(self, 
-              corpus_ids: List[str],
-              corpus_images: List[Any],
-              corpus_texts: List[str],
-              dataset_name = None) -> None:
+    def index(
+        self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str], dataset_name=None
+    ) -> None:
         """
         Optional method to perform indexing or preprocessing on the corpus.
 

--- a/src/vidore_benchmark/pipeline_evaluation/base_pipeline.py
+++ b/src/vidore_benchmark/pipeline_evaluation/base_pipeline.py
@@ -14,7 +14,7 @@ class BasePipeline(ABC):
     with their custom pipeline logic.
     """
 
-    def index(self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str]) -> None:
+    def index(self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str], dataset_name = None) -> None:
         """
         Optional method to perform indexing or preprocessing on the corpus.
 

--- a/src/vidore_benchmark/pipeline_evaluation/base_pipeline.py
+++ b/src/vidore_benchmark/pipeline_evaluation/base_pipeline.py
@@ -14,7 +14,11 @@ class BasePipeline(ABC):
     with their custom pipeline logic.
     """
 
-    def index(self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str], dataset_name = None) -> None:
+    def index(self, 
+              corpus_ids: List[str],
+              corpus_images: List[Any],
+              corpus_texts: List[str],
+              dataset_name = None) -> None:
         """
         Optional method to perform indexing or preprocessing on the corpus.
 

--- a/src/vidore_benchmark/pipeline_evaluation/evaluator.py
+++ b/src/vidore_benchmark/pipeline_evaluation/evaluator.py
@@ -54,10 +54,9 @@ def evaluate_retrieval(
     # Call the pipeline's method to get retrieval results
     # Indexing step
     start_time_indexing = time.time()
-    pipeline.index(corpus_ids=corpus_ids,
-                   corpus_images=corpus_images,
-                   corpus_texts=corpus_texts,
-                   dataset_name=dataset_name)
+    pipeline.index(
+        corpus_ids=corpus_ids, corpus_images=corpus_images, corpus_texts=corpus_texts, dataset_name=dataset_name
+    )
     indexing_time = time.time() - start_time_indexing
 
     # Avoid tracking indexing time if no other thing is done than storing the corpus

--- a/src/vidore_benchmark/pipeline_evaluation/evaluator.py
+++ b/src/vidore_benchmark/pipeline_evaluation/evaluator.py
@@ -54,7 +54,10 @@ def evaluate_retrieval(
     # Call the pipeline's method to get retrieval results
     # Indexing step
     start_time_indexing = time.time()
-    pipeline.index(corpus_ids=corpus_ids, corpus_images=corpus_images, corpus_texts=corpus_texts, dataset_name=dataset_name)
+    pipeline.index(corpus_ids=corpus_ids,
+                   corpus_images=corpus_images,
+                   corpus_texts=corpus_texts,
+                   dataset_name=dataset_name)
     indexing_time = time.time() - start_time_indexing
 
     # Avoid tracking indexing time if no other thing is done than storing the corpus

--- a/src/vidore_benchmark/pipeline_evaluation/evaluator.py
+++ b/src/vidore_benchmark/pipeline_evaluation/evaluator.py
@@ -19,6 +19,7 @@ def evaluate_retrieval(
     corpus_images: List[Any],
     corpus_texts: List[str],
     qrels: Dict[str, Dict[str, int]],
+    dataset_name: Optional[str] = None,
     metrics: List[str] = None,
     track_time: bool = True,
 ) -> Dict[str, Dict[str, float]]:
@@ -34,6 +35,7 @@ def evaluate_retrieval(
         corpus_texts: List of corpus texts (markdown strings)
         qrels: Ground truth relevance judgments in pytrec_eval format
                {query_id: {doc_id: relevance_score}}
+        dataset_name: Dataset name,
         metrics: List of metrics to calculate (default: ['ndcg_cut_10'])
         track_time: Whether to track retrieval time (default: True)
 
@@ -52,7 +54,7 @@ def evaluate_retrieval(
     # Call the pipeline's method to get retrieval results
     # Indexing step
     start_time_indexing = time.time()
-    pipeline.index(corpus_ids=corpus_ids, corpus_images=corpus_images, corpus_texts=corpus_texts)
+    pipeline.index(corpus_ids=corpus_ids, corpus_images=corpus_images, corpus_texts=corpus_texts, dataset_name=dataset_name)
     indexing_time = time.time() - start_time_indexing
 
     # Avoid tracking indexing time if no other thing is done than storing the corpus

--- a/tests/pipeline_evaluation/test_evaluator.py
+++ b/tests/pipeline_evaluation/test_evaluator.py
@@ -17,7 +17,7 @@ class MockPipeline(BasePipeline):
         self.results = results
         self.infos = infos
 
-    def index(self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str], dataset_name = None):
+    def index(self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str], dataset_name=None):
         """Mock index method."""
         pass
 

--- a/tests/pipeline_evaluation/test_evaluator.py
+++ b/tests/pipeline_evaluation/test_evaluator.py
@@ -17,7 +17,7 @@ class MockPipeline(BasePipeline):
         self.results = results
         self.infos = infos
 
-    def index(self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str]):
+    def index(self, corpus_ids: List[str], corpus_images: List[Any], corpus_texts: List[str], dataset_name = None):
         """Mock index method."""
         pass
 


### PR DESCRIPTION
This PR adds an optional `dataset_name` arg to the `index()` method of retrieval pipelines.
The `dataset_name` is useful to implement things like embedding caching, if you are interested for example on evaluating rerankers or agentic retrieval pipelines (like this [AgenticRetrievalPipeline ](https://github.com/NVIDIA/NeMo-Retriever/blob/0092ed3e66a901c4f8152ee00195657fc7531a20/retrieval-bench/src/retrieval_bench/pipelines/agentic.py#L215)([doc](https://github.com/NVIDIA/NeMo-Retriever/blob/main/retrieval-bench/submissions/vidore_v3_agentic_pipeline.md))) without having to embed the whole corpus on index() method for every evaluation.